### PR TITLE
Added some in-code documentation for rc and mux. Changed an incorrect…

### DIFF
--- a/include/mux.h
+++ b/include/mux.h
@@ -41,17 +41,17 @@ extern "C" {
 
 typedef enum
 {
-  RATE, // Channel is is in rate mode (mrad/s)
-  ANGLE, // Channel command is in angle mode (mrad)
-  THROTTLE, // Channel is direcly controlling throttle max/1000
-  PASSTHROUGH, // Channel directly passes PWM input to the mixer
+  RATE,         // Channel is is in rate mode (mrad/s)
+  ANGLE,        // Channel command is in angle mode (mrad)
+  THROTTLE,     // Channel is direcly controlling throttle max/1000
+  PASSTHROUGH,  // Channel directly passes PWM input to the mixer
 } control_type_t;
 
 typedef struct
 {
-  bool active; // Whether or not the channel is active
+  bool active;          // Whether or not the channel is active
   control_type_t type;  // What type the channel is
-  float value; // The value of the channel
+  float value;          // The value of the channel
 } control_channel_t;
 
 typedef struct
@@ -69,8 +69,27 @@ extern control_t _failsafe_control;
 
 extern bool _new_command;
 
+
+/**
+ * @brief Selects a combination of 3 possible control inputs for a single combined control output.
+ *
+ *  Selects between failsafe, offboard, and rc input control, and based off current state, muxes them into
+ *  the #_combined_control extern. 
+ * 
+ * @return False if no new commands were triggered by the 3 control inputs, otherwise true.
+ */
 bool mux_inputs();
+
+/**
+ * @brief Check if the RC is currently overriding all other commands.
+ * @return True if the RC is currently overriding other commands, otherwise false.
+ */
 bool rc_override_active();
+
+/**
+ * @brief Checks if any of the channels are currently controlled by the offboard controller.
+ * @return True if one of the muxed offboard channels are active, otherwise false.
+ */
 bool offboard_control_active();
 
 #ifdef __cplusplus

--- a/include/rc.h
+++ b/include/rc.h
@@ -62,10 +62,42 @@ typedef enum
   CPPM,
 } rc_type_t;
 
+/**
+ * @brief Initialize the RC sticks and switches.
+ *
+ * Assign channels and other values to the RC sticks and switches based on input parameters.
+ */
 void init_rc(void);
+
+/**
+ * @brief Get current stick value for the given channel.
+ * @param  channel The stick channel who's value you wish to retrieve.
+ * @return         Normalized float of the current stick value of the channel.
+ */
 float rc_stick(rc_stick_t channel);
+
+/**
+ * @brief Get the current switch value for the given channel.
+ * @param  channel The switch channel who's value you wish to retrieve.
+ * @return         True if the switch is mapped and in its on state, otherwise false.
+ */
 bool rc_switch(rc_switch_t channel);
+
+/**
+ * @brief Check if the given switch is mapped to an RC channel
+ * @param  channel The switch type to check.
+ * @return         True if this switch type was mapped to a valid RC channel, otherwise false.
+ */
 bool rc_switch_mapped(rc_switch_t channel);
+
+/**
+ * @brief Receive new RC data and update local data members.
+ *
+ *  Maps channeled inputs from the RC controller to their proper data member values within this 
+ *  class every 20ms. Upon update, signals to the mux that a new command is waiting.
+ * 
+ * @return False if it hasen't been 20ms since the last update, otherwise true.
+ */
 bool receive_rc();
 
 #endif

--- a/include/rc.h
+++ b/include/rc.h
@@ -71,14 +71,14 @@ void init_rc(void);
 
 /**
  * @brief Get current stick value for the given channel.
- * @param  channel The stick channel who's value you wish to retrieve.
+ * @param  channel The stick channel whose value you wish to retrieve.
  * @return         Normalized float of the current stick value of the channel.
  */
 float rc_stick(rc_stick_t channel);
 
 /**
  * @brief Get the current switch value for the given channel.
- * @param  channel The switch channel who's value you wish to retrieve.
+ * @param  channel The switch channel whose value you wish to retrieve.
  * @return         True if the switch is mapped and in its on state, otherwise false.
  */
 bool rc_switch(rc_switch_t channel);
@@ -96,7 +96,7 @@ bool rc_switch_mapped(rc_switch_t channel);
  *  Maps channeled inputs from the RC controller to their proper data member values within this 
  *  class every 20ms. Upon update, signals to the mux that a new command is waiting.
  * 
- * @return False if it hasen't been 20ms since the last update, otherwise true.
+ * @return False if it hasn't been 20ms since the last update, otherwise true.
  */
 bool receive_rc();
 

--- a/src/rc.c
+++ b/src/rc.c
@@ -85,25 +85,27 @@ static void init_switches()
 
   for (rc_switch_t chan = RC_SWITCH_ARM; chan < RC_SWITCHES_COUNT; chan++)
   {
+    //check for a valid stick mapping. Channels 0-3 are reserved for FXYZ
     switches[chan].mapped = switches[chan].channel > 3 && switches[chan].channel < get_param_int(PARAM_RC_NUM_CHANNELS);
     if (!switches[chan].mapped)
     {
       mavlink_log_error("invalid RC switch channel assignment: %d", switches[chan].channel); // TODO use parameter name
     }
 
+    //get switch toggle direction from associated param
     switches[chan].direction = 1;
-    switch (chan)
+    switch (switches[chan].channel)
     {
-    case RC_SWITCH_ARM:
+    case 4:
       switches[chan].direction = get_param_int(PARAM_RC_SWITCH_5_DIRECTION);
       break;
-    case RC_SWITCH_ATT_OVERRIDE:
+    case 5:
       switches[chan].direction = get_param_int(PARAM_RC_SWITCH_6_DIRECTION);
       break;
-    case RC_SWITCH_THROTTLE_OVERRIDE:
+    case 6:
       switches[chan].direction = get_param_int(PARAM_RC_SWITCH_7_DIRECTION);
       break;
-    case RC_SWITCH_ATT_TYPE:
+    case 7:
       switches[chan].direction = get_param_int(PARAM_RC_SWITCH_8_DIRECTION);
       break;
     }
@@ -148,7 +150,7 @@ bool receive_rc()
     for (rc_stick_t channel = 0; channel < RC_STICKS_COUNT; channel++)
     {
       uint16_t pwm = pwm_read(sticks[channel].channel);
-      if (sticks[channel].one_sided)
+      if (sticks[channel].one_sided) //generally only F is one_sided
       {
         stick_values[channel] = (float)(pwm - 1000) / (1000.0);
       }
@@ -163,7 +165,7 @@ bool receive_rc()
     {
       if (switches[channel].mapped)
       {
-        if (switches[channel].direction < 0)
+        if (switches[channel].direction < 0) //switch is on/off dependent on its default direction as set in the params/init_switches
         {
           switch_values[channel] = pwm_read(switches[channel].channel) < 1500;
         }


### PR DESCRIPTION
… abs call in mux to fabs. Fixed another issue with the switch statement in init_switches. The statement should be assigning directions based on the switches mapped channel, not off the channel we're currently checking for mapping.